### PR TITLE
Fjern mulighet for redigering av aktivitet

### DIFF
--- a/openapi/src/main/resources/rapportering-api.yaml
+++ b/openapi/src/main/resources/rapportering-api.yaml
@@ -62,25 +62,6 @@ paths:
       operationId: get-aktivitet-id
       tags:
         - Aktivitet
-    put:
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/AktivitetInput'
-        required: true
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Aktivitet'
-          description: OK
-      summary: Gjør endringer på en eksisterende aktivitet
-      description: Kan vel bare endre timetall
-      operationId: put-aktivitet-id
-      tags:
-        - Aktivitet
     delete:
       responses:
         '204':


### PR DESCRIPTION
Det dukker opp ganske mange komplekse problemer med validering og hva som skal være mulig å endre.

Jeg foreslår at vi kutter ut noe kompleksitet ved å ikke støtte *endring* nå, men la bruker løse det med å slette en aktivitet og legge til på nytt.