### PR TITLE
dp-vedtak sender nå ut events på når vedtak fattes i egne `@event_name`

### DIFF
--- a/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/tjenester/VedtakMottak.kt
+++ b/mediator/src/main/kotlin/no/nav/dagpenger/rapportering/tjenester/VedtakMottak.kt
@@ -25,7 +25,7 @@ internal class VedtakMottak(
     init {
         River(rapidsConnection).apply {
             validate { it.requireKey("@id") }
-            validate { it.demandValue("@event_name", "vedtak_fattet") }
+            validate { it.demandValue("@event_name", "hovedrettighet_vedtak_fattet") }
             validate { it.requireKey("ident", "behandlingId", "virkningsdato", "utfall") }
             validate { it.interestedIn("@id", "@opprettet") }
         }.register(this)

--- a/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/tjenester/VedtakMottakTest.kt
+++ b/mediator/src/test/kotlin/no/nav/dagpenger/rapportering/tjenester/VedtakMottakTest.kt
@@ -31,7 +31,7 @@ class VedtakMottakTest {
 @Language("JSON")
 private val vedtakFattetMelding = """
     {
-      "@event_name": "vedtak_fattet",
+      "@event_name": "hovedrettighet_vedtak_fattet",
       "ident": "123",
       "behandlingId": "${UUID.randomUUID()}",
       "virkningsdato": "${LocalDate.now()}",


### PR DESCRIPTION
- hovedrettighet_vedtak_fattet -> sendes når en person vedtas en "hovedrettighet" (feks Ordinære dagpenger). Ref https://navikt.github.io/dp-vedtak/#message-hovedrettighet_vedtak_fattet
- utbetaling_vedtak_fattet -> sendes når en person vedtas et utbetalingsvedtak. Ref https://navikt.github.io/dp-vedtak/#message-utbetaling_vedtak_fattet